### PR TITLE
todo lists and config defaults

### DIFF
--- a/lua/org_markdown/commands.lua
+++ b/lua/org_markdown/commands.lua
@@ -92,7 +92,7 @@ function M.register()
 
 			-- 2. Bind the key if recipe.key is not empty
 			if recipe.key and recipe.key ~= "" then
-				local key = "<leader>z" .. recipe.key
+				local key = keymaps.open_quick_note .. recipe.key
 				vim.keymap.set("n", key, "<cmd>" .. command_name .. "<CR>", {
 					desc = "OrgMarkdown: " .. recipe.title,
 					silent = true,

--- a/lua/org_markdown/config.lua
+++ b/lua/org_markdown/config.lua
@@ -51,10 +51,18 @@ local M = {
 	-- },
 }
 
-function M.setup(user_config)
-	for k, v in pairs(user_config or {}) do
-		M[k] = v
+local function merge_tables(default, user)
+	for k, v in pairs(user) do
+		if type(v) == "table" and type(default[k]) == "table" then
+			merge_tables(default[k], v)
+		else
+			default[k] = v
+		end
 	end
+end
+
+function M.setup(user_config)
+    merge_tables(M, user_config or {})
 end
 
 return M

--- a/lua/org_markdown/utils/editing.lua
+++ b/lua/org_markdown/utils/editing.lua
@@ -27,19 +27,21 @@ function M.cycle_checkbox_in_line(line, states)
 end
 
 function M.continue_todo(line)
-	local pattern = "%- %[.%](.*)"
-	local current = line:match(pattern)
+	local pattern = "(%s*)%- %[.%](.*)"
+	local current = {line:match(pattern)}
 
 	-- early return if no checkbox found
-	if not current then
+	if #current == 0 then
 		return nil
 	end
 
-    if current == "" or current == " " then
+    local spaces, contents = unpack(current)
+
+    if contents == "" or contents == " " then
         return { "" }
     end
 
-    return { line, "- [ ] " }
+    return { line, spaces .. "- [ ] " }
 end
 
 function M.edit_line_at_cursor(modifier_fn, update_cursor)

--- a/lua/org_markdown/utils/editing.lua
+++ b/lua/org_markdown/utils/editing.lua
@@ -23,16 +23,39 @@ function M.cycle_checkbox_in_line(line, states)
 	end
 
 	local next_state = states[(index % #states) + 1]
-	return line:gsub(pattern, "- [" .. next_state .. "]", 1)
+	return { (line:gsub(pattern, "- [" .. next_state .. "]", 1)) }
 end
 
-function M.edit_line_at_cursor(modifier_fn)
+function M.continue_todo(line)
+	local pattern = "%- %[.%](.*)"
+	local current = line:match(pattern)
+
+	-- early return if no checkbox found
+	if not current then
+		return nil
+	end
+
+    if current == "" or current == " " then
+        return { "" }
+    end
+
+    return { line, "- [ ] " }
+end
+
+function M.edit_line_at_cursor(modifier_fn, update_cursor)
 	local row = vim.fn.line(".") - 1
 	local line = vim.api.nvim_buf_get_lines(0, row, row + 1, false)[1]
-	local new_line = modifier_fn(line)
-	if new_line and new_line ~= line then
-		vim.api.nvim_buf_set_lines(0, row, row + 1, false, { new_line })
-	end
+	local new_lines = modifier_fn(line)
+
+	if new_lines then
+		vim.api.nvim_buf_set_lines(0, row, row + 1, false, new_lines)
+        if update_cursor then
+            vim.api.nvim_win_set_cursor(0, { row + #new_lines , #new_lines[#new_lines] })
+        end
+        return true
+    else
+    return false
+end
 end
 
 function M.setup_editing_keybinds(bufnr)
@@ -44,6 +67,20 @@ function M.setup_editing_keybinds(bufnr)
 		desc = "Cycle checkbox state",
 		buffer = bufnr,
 	})
+
+	vim.keymap.set("i", "<CR>", function()
+		local edited = M.edit_line_at_cursor(function(line)
+			return M.continue_todo(line)
+		end, true)
+
+        if not edited then
+            vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, false, true), "n", false)
+        end
+	end, {
+		desc = "extend todo list entries",
+		buffer = bufnr,
+	})
+
 end
 
 return M

--- a/lua/org_markdown/utils/picker.lua
+++ b/lua/org_markdown/utils/picker.lua
@@ -1,6 +1,5 @@
 local config = require("org_markdown.config")
-local async = require("org_markdown.async")
-local snacks = require("snacks")
+local async = require("org_markdown.utils.async")
 
 local M = {}
 
@@ -20,6 +19,7 @@ function M.pick(items, opts)
 end
 
 function M._pick_snacks(items, opts)
+	local snacks = require("snacks")
 	snacks.picker.pick({
 		source = opts.kind or "item",
 		prompt = opts.prompt or "Select item",

--- a/lua/org_markdown/utils/queries.lua
+++ b/lua/org_markdown/utils/queries.lua
@@ -1,4 +1,4 @@
-local async = require("org_markdown.async")
+local async = require("org_markdown.utils.async")
 local config = require("org_markdown.config")
 
 local M = {}


### PR DESCRIPTION
I couldn't figure out how to dodge the feedkeys, though. Also, `o` & `O` behavior? Should it replicate the `<CR>` behavior in insert mode for todo lists?

There are some other edits to make it work on my machine such as removing the snacks requirement + adjusting imports